### PR TITLE
Add llms.txt, JSON-LD, and social preview meta

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,22 +3,29 @@ import "../styles/global.css";
 import Analytics from "@vercel/analytics/astro";
 import SpeedInsights from "@vercel/speed-insights/astro";
 import { personalInfo } from "@/lib/data";
+import { DEFAULT_SITE_DESCRIPTION } from "@/lib/seo";
+
 interface Props {
   title?: string;
   description?: string;
   type?: "website" | "article";
   publishedTime?: Date;
   updatedTime?: Date;
+  image?: string;
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
 const {
   title = `${personalInfo.name} | Software Engineer`,
-  description = `${personalInfo.name} builds reliable applications, backend systems, data platforms, cloud services, and AI-powered automation.`,
+  description = DEFAULT_SITE_DESCRIPTION,
   type = "website",
   publishedTime,
   updatedTime,
+  image = personalInfo.profilePicture,
+  jsonLd,
 } = Astro.props;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin);
+const imageUrl = new URL(image, Astro.site ?? Astro.url.origin);
 ---
 
 <!doctype html>
@@ -38,9 +45,13 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin)
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:site_name" content={personalInfo.name} />
-    <meta name="twitter:card" content="summary" />
+    <meta property="og:image" content={imageUrl} />
+    <meta property="og:image:alt" content={title} />
+    <meta property="og:locale" content="en_US" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={imageUrl} />
     {
       type === "article" && publishedTime && (
         <meta property="article:published_time" content={publishedTime.toISOString()} />
@@ -52,6 +63,9 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin)
       )
     }
     {type === "article" && <meta property="article:author" content={personalInfo.name} />}
+    {jsonLd && (
+      <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+    )}
     <title>{title}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,7 +3,7 @@ import "../styles/global.css";
 import Analytics from "@vercel/analytics/astro";
 import SpeedInsights from "@vercel/speed-insights/astro";
 import { personalInfo } from "@/lib/data";
-import { DEFAULT_SITE_DESCRIPTION } from "@/lib/seo";
+import { DEFAULT_SITE_DESCRIPTION, serializeJsonLd } from "@/lib/seo";
 
 interface Props {
   title?: string;
@@ -64,7 +64,7 @@ const imageUrl = new URL(image, Astro.site ?? Astro.url.origin);
     }
     {type === "article" && <meta property="article:author" content={personalInfo.name} />}
     {jsonLd && (
-      <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+      <script is:inline type="application/ld+json" set:html={serializeJsonLd(jsonLd)} />
     )}
     <title>{title}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/lib/llms.ts
+++ b/src/lib/llms.ts
@@ -1,0 +1,69 @@
+import type { BlogPost } from "@/lib/blog";
+import { personalInfo, selectedWork, workExperience } from "@/lib/data";
+import { absoluteUrl, DEFAULT_SITE_DESCRIPTION } from "@/lib/seo";
+
+export function buildLlmsTxt(origin: string, posts: BlogPost[]): string {
+  const home = absoluteUrl(origin, "/");
+  const blog = absoluteUrl(origin, "/blog/");
+  const resume = absoluteUrl(origin, personalInfo.resume);
+  const experienceAnchor = absoluteUrl(origin, "/#experience");
+  const workAnchor = absoluteUrl(origin, "/#work");
+  const currentRole = workExperience[0];
+
+  const lines: string[] = [
+    `# ${personalInfo.name}`,
+    `> ${DEFAULT_SITE_DESCRIPTION}`,
+    "",
+    personalInfo.heroDescription,
+  ];
+
+  if (currentRole) {
+    lines.push(
+      "",
+      `Current role: ${currentRole.position} at ${currentRole.company} (${currentRole.period}).`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Pages",
+    `- [Home](${home}): Experience, selected work, skills, awards, and education`,
+    `- [Blog](${blog}): Writing and notes on software engineering`,
+    `- [Resume](${resume}): PDF resume`,
+    "",
+    "## Experience",
+  );
+
+  for (const job of workExperience) {
+    const summary = job.achievements[0] ?? "";
+    lines.push(
+      `- [${job.company} — ${job.position}](${experienceAnchor}): ${job.period}. ${summary}`,
+    );
+  }
+
+  lines.push("", "## Selected work");
+
+  for (const project of selectedWork) {
+    lines.push(`- [${project.title}](${workAnchor}): ${project.summary}`);
+  }
+
+  if (posts.length > 0) {
+    lines.push("", "## Blog");
+
+    for (const post of posts) {
+      lines.push(
+        `- [${post.data.title}](${absoluteUrl(origin, `/blog/${post.id}/`)}): ${post.data.description}`,
+      );
+    }
+  }
+
+  lines.push(
+    "",
+    "## Elsewhere",
+    `- [GitHub](${personalInfo.github})`,
+    `- [LinkedIn](${personalInfo.linkedin})`,
+    `- [Email](mailto:${personalInfo.email})`,
+  );
+
+  return `${lines.join("\n")}\n`;
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,59 @@
+import type { BlogPost } from "@/lib/blog";
+import { personalInfo, workExperience } from "@/lib/data";
+
+export const DEFAULT_SITE_DESCRIPTION = `${personalInfo.name} builds reliable applications, backend systems, data platforms, cloud services, and AI-powered automation.`;
+
+export function absoluteUrl(origin: string, pathname: string): string {
+  return new URL(pathname, origin).href;
+}
+
+export function buildPersonJsonLd(origin: string): Record<string, unknown> {
+  const currentRole = workExperience[0];
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: personalInfo.name,
+    email: personalInfo.email,
+    url: absoluteUrl(origin, "/"),
+    image: absoluteUrl(origin, personalInfo.profilePicture),
+    sameAs: [personalInfo.github, personalInfo.linkedin],
+    description: DEFAULT_SITE_DESCRIPTION,
+    ...(currentRole
+      ? {
+          jobTitle: currentRole.position,
+          worksFor: {
+            "@type": "Organization",
+            name: currentRole.company,
+          },
+        }
+      : {}),
+  };
+}
+
+export function buildBlogPostingJsonLd(origin: string, post: BlogPost): Record<string, unknown> {
+  const postUrl = absoluteUrl(origin, `/blog/${post.id}/`);
+  const author = {
+    "@type": "Person",
+    name: personalInfo.name,
+    url: absoluteUrl(origin, "/"),
+    sameAs: [personalInfo.github, personalInfo.linkedin],
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.data.title,
+    description: post.data.description,
+    datePublished: post.data.pubDate.toISOString(),
+    ...(post.data.updatedDate ? { dateModified: post.data.updatedDate.toISOString() } : {}),
+    author,
+    publisher: author,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": postUrl,
+    },
+    url: postUrl,
+    image: absoluteUrl(origin, personalInfo.profilePicture),
+  };
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -7,6 +7,13 @@ export function absoluteUrl(origin: string, pathname: string): string {
   return new URL(pathname, origin).href;
 }
 
+/** Serialize JSON-LD for embedding in a <script> tag without breaking out of it. */
+export function serializeJsonLd(
+  value: Record<string, unknown> | Record<string, unknown>[],
+): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
 export function buildPersonJsonLd(origin: string): Record<string, unknown> {
   const currentRole = workExperience[0];
 

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -4,6 +4,7 @@ import Footer from "@/components/Footer";
 import GlassHeader from "@/components/GlassHeader";
 import Layout from "@/layouts/Layout.astro";
 import { formatPostDate, getPublishedPosts, type BlogPost } from "@/lib/blog";
+import { buildBlogPostingJsonLd } from "@/lib/seo";
 
 export async function getStaticPaths() {
   const posts = await getPublishedPosts();
@@ -20,6 +21,8 @@ interface Props {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
+const origin = (Astro.site ?? Astro.url.origin).toString();
+const jsonLd = buildBlogPostingJsonLd(origin, post);
 ---
 
 <Layout
@@ -27,6 +30,7 @@ const { Content } = await render(post);
   description={post.data.description}
   type="article"
   publishedTime={post.data.pubDate}
+  jsonLd={jsonLd}
   {...(post.data.updatedDate ? { updatedTime: post.data.updatedDate } : {})}
 >
   <div class="sticky top-0 z-50">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,9 +8,13 @@ import ProjectsSection from "@/components/ProjectsSection";
 import AwardsSection from "@/components/AwardsSection";
 import EducationSection from "@/components/EducationSection";
 import Footer from "@/components/Footer";
+import { buildPersonJsonLd } from "@/lib/seo";
+
+const origin = (Astro.site ?? Astro.url.origin).toString();
+const jsonLd = buildPersonJsonLd(origin);
 ---
 
-<Layout>
+<Layout jsonLd={jsonLd}>
   <div class="sticky top-0 z-50">
     <GlassHeader client:load />
   </div>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from "astro";
+import { getPublishedPosts } from "@/lib/blog";
+import { buildLlmsTxt } from "@/lib/llms";
+
+export const GET: APIRoute = async ({ site, url }) => {
+  const origin = (site ?? url.origin).toString();
+  const posts = await getPublishedPosts();
+  const body = buildLlmsTxt(origin, posts);
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- Add a dynamic `/llms.txt` endpoint that curates portfolio content from `data.ts` and published blog posts for LLM-friendly discovery.
- Add JSON-LD structured data (`Person` on home, `BlogPosting` on posts) via shared helpers in `src/lib/seo.ts`.
- Improve social sharing meta with `og:image`, `og:locale`, and `summary_large_image` Twitter cards using the existing profile photo.

## Test plan
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [ ] Verify `/llms.txt` in production after deploy
- [ ] Spot-check JSON-LD and OG tags on `/` and a blog post (view source or Rich Results Test)