### PR TITLE
Make llms.txt person-first

### DIFF
--- a/src/lib/llms.ts
+++ b/src/lib/llms.ts
@@ -20,7 +20,7 @@ export function buildLlmsTxt(origin: string, posts: BlogPost[]): string {
     "",
     personalInfo.heroDescription,
     "",
-    "This site is the personal portfolio of Rishikesh S: background, selected work, skills, writing, and contact links.",
+    `This site is the personal portfolio of ${personalInfo.name}: background, selected work, skills, writing, and contact links.`,
   ];
 
   if (currentRole) {
@@ -36,44 +36,55 @@ export function buildLlmsTxt(origin: string, posts: BlogPost[]): string {
     `- [Home](${home}): Portfolio overview — experience, selected work, skills, awards, and education`,
     `- [Blog](${blog}): Writing and notes on software engineering`,
     `- [Resume](${resume}): PDF resume`,
-    "",
-    "## Skills",
   );
 
-  for (const group of skills) {
-    lines.push(`- [${group.label}](${skillsAnchor}): ${group.items.join(", ")}`);
+  if (skills.length > 0) {
+    lines.push("", "## Skills");
+
+    for (const group of skills) {
+      lines.push(`- [${group.label}](${skillsAnchor}): ${group.items.join(", ")}`);
+    }
   }
 
-  lines.push("", "## Selected work");
+  if (selectedWork.length > 0) {
+    lines.push("", "## Selected work");
 
-  for (const project of selectedWork) {
-    lines.push(
-      `- [${project.title}](${workAnchor}): ${project.summary} Stack: ${project.stack.join(", ")}.`,
-    );
+    for (const project of selectedWork) {
+      lines.push(
+        `- [${project.title}](${workAnchor}): ${project.summary} Stack: ${project.stack.join(", ")}.`,
+      );
+    }
   }
 
-  lines.push("", "## Experience");
+  if (workExperience.length > 0) {
+    lines.push("", "## Experience");
 
-  for (const job of workExperience) {
-    lines.push(
-      `- [${job.position} · ${job.company}](${experienceAnchor}): ${job.period}, ${job.location}. Stack: ${job.stack.join(", ")}.`,
-    );
+    for (const job of workExperience) {
+      lines.push(
+        `- [${job.position} · ${job.company}](${experienceAnchor}): ${job.period}, ${job.location}. Stack: ${job.stack.join(", ")}.`,
+      );
+    }
   }
 
   if (educationEntry) {
+    const highlights =
+      educationEntry.achievements.length > 0 ? ` ${educationEntry.achievements.join(" ")}` : "";
+
     lines.push(
       "",
       "## Education",
-      `- [${educationEntry.degree}](${educationAnchor}): ${educationEntry.institution}, ${educationEntry.location} (${educationEntry.period}). Department president, G20 student delegate, and hackathon competitor.`,
+      `- [${educationEntry.degree}](${educationAnchor}): ${educationEntry.institution}, ${educationEntry.location} (${educationEntry.period}).${highlights}`,
     );
   }
 
-  lines.push("", "## Awards");
+  if (awards.length > 0) {
+    lines.push("", "## Awards");
 
-  for (const award of awards) {
-    lines.push(
-      `- [${award.name}](${awardsAnchor}): ${award.position}, ${award.issuer} (${award.date}, ${award.type})`,
-    );
+    for (const award of awards) {
+      lines.push(
+        `- [${award.name}](${awardsAnchor}): ${award.position}, ${award.issuer} (${award.date}, ${award.type})`,
+      );
+    }
   }
 
   if (posts.length > 0) {

--- a/src/lib/llms.ts
+++ b/src/lib/llms.ts
@@ -1,5 +1,5 @@
 import type { BlogPost } from "@/lib/blog";
-import { personalInfo, selectedWork, workExperience } from "@/lib/data";
+import { awards, education, personalInfo, selectedWork, skills, workExperience } from "@/lib/data";
 import { absoluteUrl, DEFAULT_SITE_DESCRIPTION } from "@/lib/seo";
 
 export function buildLlmsTxt(origin: string, posts: BlogPost[]): string {
@@ -8,43 +8,72 @@ export function buildLlmsTxt(origin: string, posts: BlogPost[]): string {
   const resume = absoluteUrl(origin, personalInfo.resume);
   const experienceAnchor = absoluteUrl(origin, "/#experience");
   const workAnchor = absoluteUrl(origin, "/#work");
+  const skillsAnchor = absoluteUrl(origin, "/#skills");
+  const awardsAnchor = absoluteUrl(origin, "/#awards");
+  const educationAnchor = absoluteUrl(origin, "/#education");
   const currentRole = workExperience[0];
+  const educationEntry = education[0];
 
   const lines: string[] = [
     `# ${personalInfo.name}`,
     `> ${DEFAULT_SITE_DESCRIPTION}`,
     "",
     personalInfo.heroDescription,
+    "",
+    "This site is the personal portfolio of Rishikesh S: background, selected work, skills, writing, and contact links.",
   ];
 
   if (currentRole) {
     lines.push(
       "",
-      `Current role: ${currentRole.position} at ${currentRole.company} (${currentRole.period}).`,
+      `Currently ${currentRole.position} at ${currentRole.company} (${currentRole.period}), focused on reliable systems from design through production support.`,
     );
   }
 
   lines.push(
     "",
     "## Pages",
-    `- [Home](${home}): Experience, selected work, skills, awards, and education`,
+    `- [Home](${home}): Portfolio overview — experience, selected work, skills, awards, and education`,
     `- [Blog](${blog}): Writing and notes on software engineering`,
     `- [Resume](${resume}): PDF resume`,
     "",
-    "## Experience",
+    "## Skills",
   );
 
-  for (const job of workExperience) {
-    const summary = job.achievements[0] ?? "";
-    lines.push(
-      `- [${job.company} — ${job.position}](${experienceAnchor}): ${job.period}. ${summary}`,
-    );
+  for (const group of skills) {
+    lines.push(`- [${group.label}](${skillsAnchor}): ${group.items.join(", ")}`);
   }
 
   lines.push("", "## Selected work");
 
   for (const project of selectedWork) {
-    lines.push(`- [${project.title}](${workAnchor}): ${project.summary}`);
+    lines.push(
+      `- [${project.title}](${workAnchor}): ${project.summary} Stack: ${project.stack.join(", ")}.`,
+    );
+  }
+
+  lines.push("", "## Experience");
+
+  for (const job of workExperience) {
+    lines.push(
+      `- [${job.position} · ${job.company}](${experienceAnchor}): ${job.period}, ${job.location}. Stack: ${job.stack.join(", ")}.`,
+    );
+  }
+
+  if (educationEntry) {
+    lines.push(
+      "",
+      "## Education",
+      `- [${educationEntry.degree}](${educationAnchor}): ${educationEntry.institution}, ${educationEntry.location} (${educationEntry.period}). Department president, G20 student delegate, and hackathon competitor.`,
+    );
+  }
+
+  lines.push("", "## Awards");
+
+  for (const award of awards) {
+    lines.push(
+      `- [${award.name}](${awardsAnchor}): ${award.position}, ${award.issuer} (${award.date}, ${award.type})`,
+    );
   }
 
   if (posts.length > 0) {
@@ -60,9 +89,9 @@ export function buildLlmsTxt(origin: string, posts: BlogPost[]): string {
   lines.push(
     "",
     "## Elsewhere",
-    `- [GitHub](${personalInfo.github})`,
-    `- [LinkedIn](${personalInfo.linkedin})`,
-    `- [Email](mailto:${personalInfo.email})`,
+    `- [GitHub](${personalInfo.github}): Open-source and personal projects`,
+    `- [LinkedIn](${personalInfo.linkedin}): Professional profile`,
+    `- [Email](mailto:${personalInfo.email}): Direct contact`,
   );
 
   return `${lines.join("\n")}\n`;


### PR DESCRIPTION
## Summary
- Rebalance `/llms.txt` around Rishikesh as the subject: skills, selected work, education, and awards come before employer detail.
- Replace long Chatbyte achievement dumps in Experience with short role + stack lines.
- Clarify in the intro that this is a personal portfolio site.

## Test plan
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [ ] Spot-check `/llms.txt` after deploy — should read as a personal profile, not a Chatbyte brief